### PR TITLE
Add / at the end of tmp folder in COPY

### DIFF
--- a/{{cookiecutter.project_folder}}/Dockerfile
+++ b/{{cookiecutter.project_folder}}/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir $APP_HOME && adduser -S -D -H python
 RUN chown -R python $APP_HOME
 WORKDIR $APP_HOME
 RUN pip install pipenv
-COPY Pipfile* /tmp
+COPY Pipfile* /tmp/
 RUN cd /tmp && pipenv lock --requirements > requirements.txt
 RUN pip install -r /tmp/requirements.txt
 RUN pip install gevent==1.2.2 gunicorn==19.7.1


### PR DESCRIPTION
Docker complains about a missing / at the end of tmp folder. Maybe this is something related to the latest version of Docker, I think it should keep the compatibility with previous versions :)