### PR TITLE
Update swagger.yaml

### DIFF
--- a/{{cookiecutter.project_folder}}/project/swagger/swagger.yaml
+++ b/{{cookiecutter.project_folder}}/project/swagger/swagger.yaml
@@ -38,7 +38,7 @@ paths:
       produces:
       - "application/json"
       responses:
-        200:
+        "200":
           description: "A detail view with a message"
           schema:
             $ref: '#/definitions/dummy_msg'
@@ -54,7 +54,7 @@ paths:
       produces:
       - "application/json"
       responses:
-        200:
+        "200":
           description: "A detail view with a message"
           schema:
             $ref: '#/definitions/dummy_msg'


### PR DESCRIPTION
When set in strict mode, response is required to be byte stream/string, int shall give error.